### PR TITLE
Added support for serial

### DIFF
--- a/src/EfCore.Ydb/src/Metadata/Internal/YdbAnnotationNames.cs
+++ b/src/EfCore.Ydb/src/Metadata/Internal/YdbAnnotationNames.cs
@@ -1,0 +1,8 @@
+namespace EfCore.Ydb.Metadata.Internal;
+
+public static class YdbAnnotationNames
+{
+    public const string Prefix = "Ydb";
+
+    public const string Serial = Prefix + "Serial";
+}

--- a/src/EfCore.Ydb/src/Metadata/Internal/YdbAnnotationProvider.cs
+++ b/src/EfCore.Ydb/src/Metadata/Internal/YdbAnnotationProvider.cs
@@ -1,12 +1,36 @@
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace EfCore.Ydb.Metadata.Internal;
 
 public class YdbAnnotationProvider : RelationalAnnotationProvider
 {
-    public YdbAnnotationProvider(
-        RelationalAnnotationProviderDependencies dependencies
-    ) : base(dependencies)
+    public YdbAnnotationProvider(RelationalAnnotationProviderDependencies dependencies) : base(dependencies)
     {
+    }
+
+    public override IEnumerable<IAnnotation> For(IColumn column, bool designTime)
+    {
+        if (!designTime)
+        {
+            yield break;
+        }
+
+        // TODO: Add Yson here too?
+        if (column is JsonColumn)
+        {
+            yield break;
+        }
+
+        var property = column.PropertyMappings[0].Property;
+
+        if (property.ValueGenerated == ValueGenerated.OnAdd
+            && property.ClrType == typeof(int)
+            && property.FindTypeMapping()?.Converter == null)
+        {
+            yield return new Annotation(YdbAnnotationNames.Serial, true);
+        }
     }
 }


### PR DESCRIPTION
Support for SERIAL type

 (I cannot find information about SERIAL in current version of documentation although I recall seeing it a few days ago. Looks like it was deleted. But this type is crucial for tests so.. looks like we don't have a choice)
 
For following table:
```
public record class MyTable
{
    public int Id { get; set; }

    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
    public int MyCustomSerial { get; set; }
}
``` 
The type for Id will be replaced with SERIAL (default behaviour. If column's name is Id or {TableName}Id, then it is considered a Primary key in Ef). The same applies to MyCustomSerial (because we specified that it's serial using annotation) 