### PR TITLE
More types. Added basic json, decimal, string (alternative for TEXT),…

### DIFF
--- a/src/EfCore.Ydb/src/Abstractions/YdbStringAttribute.cs
+++ b/src/EfCore.Ydb/src/Abstractions/YdbStringAttribute.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace EfCore.Ydb.Abstractions;
+
+[AttributeUsage(AttributeTargets.Property)]
+public class YdbStringAttribute: Attribute
+{
+}

--- a/src/EfCore.Ydb/src/Metadata/Conventions/YdbConventionSetBuilder.cs
+++ b/src/EfCore.Ydb/src/Metadata/Conventions/YdbConventionSetBuilder.cs
@@ -1,3 +1,4 @@
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 
 namespace EfCore.Ydb.Metadata.Conventions;
@@ -10,5 +11,12 @@ public class YdbConventionSetBuilder
         RelationalConventionSetBuilderDependencies relationalDependencies
     ) : base(dependencies, relationalDependencies)
     {
+    }
+
+    public override ConventionSet CreateConventionSet()
+    {
+        var coreConventions = base.CreateConventionSet();
+        coreConventions.Add(new YdbStringAttributeConvention(Dependencies));
+        return coreConventions;
     }
 }

--- a/src/EfCore.Ydb/src/Metadata/Conventions/YdbStringAttributeConvention.cs
+++ b/src/EfCore.Ydb/src/Metadata/Conventions/YdbStringAttributeConvention.cs
@@ -1,0 +1,26 @@
+using System.Reflection;
+using EfCore.Ydb.Abstractions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+
+namespace EfCore.Ydb.Metadata.Conventions;
+
+public class YdbStringAttributeConvention
+    : PropertyAttributeConventionBase<YdbStringAttribute>
+{
+    public YdbStringAttributeConvention(ProviderConventionSetBuilderDependencies dependencies) : base(dependencies)
+    {
+    }
+
+    protected override void ProcessPropertyAdded(
+        IConventionPropertyBuilder propertyBuilder,
+        YdbStringAttribute attribute,
+        MemberInfo clrMember,
+        IConventionContext context
+    )
+    {
+        propertyBuilder.HasColumnType("string");
+    }
+}

--- a/src/EfCore.Ydb/src/Query/Internal/YdbAggregateMethodCallTranslatorProvider.cs
+++ b/src/EfCore.Ydb/src/Query/Internal/YdbAggregateMethodCallTranslatorProvider.cs
@@ -14,7 +14,7 @@ public class YdbAggregateMethodCallTranslatorProvider
 
         AddTranslators(
         [
-            new YdbQueryableAggregateMethodTranslator(sqlExpressionFactory)
+            new YdbQueryableAggregateMethodTranslator(sqlExpressionFactory, dependencies.RelationalTypeMappingSource)
         ]);
     }
 }

--- a/src/EfCore.Ydb/src/Query/Internal/YdbQuerySqlGeneratorFactory.cs
+++ b/src/EfCore.Ydb/src/Query/Internal/YdbQuerySqlGeneratorFactory.cs
@@ -1,15 +1,22 @@
 using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace EfCore.Ydb.Query.Internal;
 
 public class YdbQuerySqlGeneratorFactory : IQuerySqlGeneratorFactory
 {
     private readonly QuerySqlGeneratorDependencies _dependencies;
+    private readonly IRelationalTypeMappingSource _typeMappingSource;
 
     public YdbQuerySqlGeneratorFactory(
-        QuerySqlGeneratorDependencies dependencies
-    ) => _dependencies = dependencies;
+        QuerySqlGeneratorDependencies dependencies,
+        IRelationalTypeMappingSource typeMappingSource
+    )
+    {
+        _dependencies = dependencies;
+        _typeMappingSource = typeMappingSource;
+    }
 
     public QuerySqlGenerator Create()
-        => new YdbQuerySqlGenerator(_dependencies);
+        => new YdbQuerySqlGenerator(_dependencies, _typeMappingSource);
 }

--- a/src/EfCore.Ydb/src/Storage/Internal/Mapping/YdbBytesTypeMapping.cs
+++ b/src/EfCore.Ydb/src/Storage/Internal/Mapping/YdbBytesTypeMapping.cs
@@ -1,0 +1,38 @@
+using System.Text;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.Json;
+
+namespace EfCore.Ydb.Storage.Internal.Mapping;
+
+public class YdbBytesTypeMapping : RelationalTypeMapping
+{
+    public static YdbBytesTypeMapping Default { get; } = new();
+
+    public YdbBytesTypeMapping() : base(
+        new RelationalTypeMappingParameters(
+            new CoreTypeMappingParameters(
+                typeof(byte[]),
+                jsonValueReaderWriter: JsonByteArrayReaderWriter.Instance
+            ),
+            storeType: "bytes",
+            storeTypePostfix: StoreTypePostfix.None,
+            dbType: System.Data.DbType.Binary,
+            unicode: false
+        )
+    )
+    {
+    }
+
+    protected YdbBytesTypeMapping(RelationalTypeMappingParameters parameters) : base(parameters)
+    {
+    }
+
+    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+        => new YdbBytesTypeMapping(parameters);
+
+    protected override string GenerateNonNullSqlLiteral(object value)
+    {
+        var bytes = (byte[])value;
+        return $"'{Encoding.UTF8.GetString(bytes)}'";
+    }
+}

--- a/src/EfCore.Ydb/src/Storage/Internal/Mapping/YdbDecimalTypeMapping.cs
+++ b/src/EfCore.Ydb/src/Storage/Internal/Mapping/YdbDecimalTypeMapping.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Data.Common;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace EfCore.Ydb.Storage.Internal.Mapping;
+
+public class YdbDecimalTypeMapping : RelationalTypeMapping
+{
+    public YdbDecimalTypeMapping(Type? type) : this(
+        new RelationalTypeMappingParameters(
+            new CoreTypeMappingParameters(type ?? typeof(decimal)),
+            storeType: "decimal",
+            dbType: System.Data.DbType.Decimal
+        )
+    )
+    {
+    }
+
+    protected YdbDecimalTypeMapping(RelationalTypeMappingParameters parameters) : base(parameters)
+    {
+    }
+
+    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+        => new YdbDecimalTypeMapping(parameters);
+
+    protected override string ProcessStoreType(
+        RelationalTypeMappingParameters parameters, string storeType, string storeTypeNameBase
+    )
+    {
+        if (storeType == "BigInteger" && parameters.Precision != null)
+        {
+            return $"DECIMAL({parameters.Precision}, 0)";
+        }
+        else
+        {
+            return parameters.Precision is null
+                ? storeType
+                : parameters.Scale is null
+                    ? $"DECIMAL({parameters.Precision}, 0)"
+                    : $"DECIMAL({parameters.Precision},{parameters.Scale})";
+        }
+    }
+
+    public override MethodInfo GetDataReaderMethod()
+    {
+        return typeof(DbDataReader).GetRuntimeMethod(nameof(DbDataReader.GetDecimal), [typeof(int)])!;
+    }
+}

--- a/src/EfCore.Ydb/src/Storage/Internal/Mapping/YdbJsonTypeMapping.cs
+++ b/src/EfCore.Ydb/src/Storage/Internal/Mapping/YdbJsonTypeMapping.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.IO;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace EfCore.Ydb.Storage.Internal.Mapping;
+
+public class YdbJsonTypeMapping : JsonTypeMapping
+{
+    public YdbJsonTypeMapping(string storeType, Type clrType, DbType? dbType) : base(storeType, clrType, dbType)
+    {
+    }
+
+    protected YdbJsonTypeMapping(RelationalTypeMappingParameters parameters) : base(parameters)
+    {
+    }
+
+    private static readonly MethodInfo GetStringMethod
+        = typeof(DbDataReader).GetRuntimeMethod(nameof(DbDataReader.GetString), [typeof(int)])!;
+
+    private static readonly PropertyInfo UTF8Property
+        = typeof(Encoding).GetProperty(nameof(Encoding.UTF8))!;
+
+    private static readonly MethodInfo EncodingGetBytesMethod
+        = typeof(Encoding).GetMethod(nameof(Encoding.GetBytes), [typeof(string)])!;
+
+    private static readonly ConstructorInfo MemoryStreamConstructor
+        = typeof(MemoryStream).GetConstructor([typeof(byte[])])!;
+
+    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+        => new YdbJsonTypeMapping(parameters);
+
+    public override MethodInfo GetDataReaderMethod()
+        => GetStringMethod;
+
+    protected override string GenerateNonNullSqlLiteral(object value)
+    {
+        switch (value)
+        {
+            case JsonDocument _:
+            case JsonElement _:
+            {
+                using var stream = new MemoryStream();
+                using var writer = new Utf8JsonWriter(stream);
+                if (value is JsonDocument doc)
+                {
+                    doc.WriteTo(writer);
+                }
+                else
+                {
+                    ((JsonElement)value).WriteTo(writer);
+                }
+
+                writer.Flush();
+                return $"'{Encoding.UTF8.GetString(stream.ToArray())}'";
+            }
+            case string s:
+                return $"'{s}'";
+            default:
+                return $"'{JsonSerializer.Serialize(value)}'";
+        }
+    }
+
+    public override Expression CustomizeDataReaderExpression(Expression expression)
+        => Expression.New(
+            MemoryStreamConstructor,
+            Expression.Call(
+                Expression.Property(null, UTF8Property),
+                EncodingGetBytesMethod,
+                expression));
+}

--- a/src/EfCore.Ydb/src/Storage/Internal/Mapping/YdbStringTypeMapping.cs
+++ b/src/EfCore.Ydb/src/Storage/Internal/Mapping/YdbStringTypeMapping.cs
@@ -1,0 +1,40 @@
+using System.Text;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.Json;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace EfCore.Ydb.Storage.Internal.Mapping;
+
+public class YdbStringTypeMapping : RelationalTypeMapping
+{
+    public static YdbStringTypeMapping Default { get; } = new();
+
+    public YdbStringTypeMapping() : base(
+        new RelationalTypeMappingParameters(
+            new CoreTypeMappingParameters(
+                typeof(byte[]),
+                new StringToBytesConverter(Encoding.UTF8),
+                jsonValueReaderWriter: JsonByteArrayReaderWriter.Instance
+            ),
+            storeType: "string",
+            storeTypePostfix: StoreTypePostfix.None,
+            dbType: System.Data.DbType.Binary,
+            unicode: false
+        )
+    )
+    {
+    }
+
+    protected YdbStringTypeMapping(RelationalTypeMappingParameters parameters) : base(parameters)
+    {
+    }
+
+    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+        => new YdbStringTypeMapping(parameters);
+
+    protected override string GenerateNonNullSqlLiteral(object value)
+    {
+        var bytes = (byte[])value;
+        return $"'{Encoding.UTF8.GetString(bytes)}'";
+    }
+}


### PR DESCRIPTION
New types: json (only simple queries), decimal, string (alternative for TEXT), date/time, bytes (blobs).

To use string instead of text your property should be marked with `YdbString` attribute